### PR TITLE
LANraragi: API fixes as of 0.6.7

### DIFF
--- a/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
+++ b/src/all/lanraragi/src/eu/kanade/tachiyomi/extension/all/lanraragi/LANraragi.kt
@@ -64,7 +64,7 @@ open class LANraragi(override val lang: String) : ConfigurableSource, HttpSource
         val pages = ArrayList<Page>()
         var i = 0
         pageList.pages.forEach { url ->
-            val uri = Uri.parse("$baseUrl/${url.trimStart('.')}")
+            val uri = Uri.parse("$baseUrl/${url.trimStart('.').trimStart('/')}")
 
             pages.add(Page(i++, uri.toString(), uri.toString(), uri))
         }
@@ -194,7 +194,7 @@ open class LANraragi(override val lang: String) : ConfigurableSource, HttpSource
                     genre = a.tags
 
                     if(apiKey.isNotEmpty()) {
-                        url = "$url&apiKey=$apiKey"
+                        url = "$url&key=$apiKey"
                     }
                 })
             }


### PR DESCRIPTION
Couldn't have this extension be left behind. Though I wouldn't mind it being wrapped up and made available with out having to package it myself!

- Image routing was 404ing in Mojolicious due to preceding `/` resulting in `//api/page`
- `genericMangaParse` was failing with "no fun mode" due to wrong URL parameter for `key`

Nothing big here, feel free to toss it out and do it proper if needed.